### PR TITLE
fix(libs/common/spotify-service): formatted track href value

### DIFF
--- a/libs/common/src/spotify/mocks/track.mock.ts
+++ b/libs/common/src/spotify/mocks/track.mock.ts
@@ -153,7 +153,7 @@ export const formattedTrackMock: FormattedTrack = {
   ],
   name: 'Kobresia',
   duration: 1000,
-  href: 'https://api.spotify.com/v1/tracks/5O6MFTh1rd9PeN8XEn1yCS',
+  href: 'https://open.spotify.com/track/5O6MFTh1rd9PeN8XEn1yCS',
   playedAt: '2022-11-26T11:01:10.040Z',
 }
 

--- a/libs/common/src/spotify/spotify.service.ts
+++ b/libs/common/src/spotify/spotify.service.ts
@@ -30,7 +30,7 @@ export class SpotifyService {
         name,
         album,
         artists,
-        href,
+        external_urls: { spotify: href },
         duration_ms,
         progress_ms,
         played_at,


### PR DESCRIPTION
closes #66 